### PR TITLE
Enhance resources and inventory

### DIFF
--- a/run.py
+++ b/run.py
@@ -4,7 +4,7 @@ from civsim import Entity, Simulation, World, SimulationUI
 
 
 def main() -> None:
-    world = World(width=20, height=15, seed=42)
+    world = World(width=60, height=40, seed=42)
     entities = [Entity(id=i, x=world.width // 2, y=world.height // 2) for i in range(5)]
     sim = Simulation(world=world, entities=entities)
     ui = SimulationUI(sim, ticks_per_second=2)

--- a/src/civsim/__init__.py
+++ b/src/civsim/__init__.py
@@ -1,7 +1,7 @@
 """Convenience exports for the civsim package."""
 
 from .world import World, Biome
-from .entity import Entity
+from .entity import Entity, ReproductionRules
 from .simulation import Simulation
 from .visualize import (
     render_ascii,
@@ -15,6 +15,7 @@ __all__ = [
     "World",
     "Biome",
     "Entity",
+    "ReproductionRules",
     "Simulation",
     "render_ascii",
     "render_svg",

--- a/src/civsim/simulation.py
+++ b/src/civsim/simulation.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import List
 
-from .entity import Entity
+from .entity import Entity, ReproductionRules
 from .world import World
 
 
@@ -16,23 +16,40 @@ class Simulation:
     world: World
     entities: List[Entity]
     tick: int = 0
+    reproduction_rules: ReproductionRules = field(default_factory=ReproductionRules)
 
     def step(self) -> None:
         """Advance the simulation by one tick."""
 
         new_entities: List[Entity] = []
+
+        occupied: dict[tuple[int, int], int] = {}
+        for ent in self.entities:
+            pos = (ent.x, ent.y)
+            occupied[pos] = occupied.get(pos, 0) + 1
+
         for i, entity in enumerate(self.entities):
             for other in self.entities[i + 1 :]:
                 if (
                     entity.x == other.x
                     and entity.y == other.y
-                    and entity.can_reproduce()
-                    and other.can_reproduce()
+                    and entity.can_reproduce(self.reproduction_rules, self.tick)
+                    and other.can_reproduce(self.reproduction_rules, self.tick)
                 ):
                     child_id = len(self.entities) + len(new_entities)
-                    child = entity.reproduce_with(other, child_id)
+                    child = entity.reproduce_with(other, child_id, self.tick)
                     new_entities.append(child)
                     break
-            entity.take_turn(self.world)
+
+            pos = (entity.x, entity.y)
+            occupied[pos] -= 1
+            if occupied[pos] == 0:
+                del occupied[pos]
+
+            entity.take_turn(self.world, set(occupied.keys()))
+
+            pos = (entity.x, entity.y)
+            occupied[pos] = occupied.get(pos, 0) + 1
+
         self.entities.extend(new_entities)
         self.tick += 1

--- a/src/civsim/visualize.py
+++ b/src/civsim/visualize.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import List
 
 from .entity import Entity
-from .world import World, Biome
+from .world import World, Biome, Resource
 
 
 def render_ascii(world: World, entities: List[Entity]) -> str:
@@ -40,6 +40,18 @@ def render_svg(world: World, entities: List[Entity], tile_size: int = 20) -> str
         Biome.DESERT: "#e0c469",
         Biome.WATER: "#1e90ff",
     }
+    res_colors = {
+        Resource.WOOD: "#8b4513",
+        Resource.STONE: "#808080",
+        Resource.CLAY: "#b5651d",
+        Resource.WATER: "#00bfff",
+        Resource.FOOD: "#ff6347",
+        Resource.ANIMAL: "#fafad2",
+        Resource.IRON: "#b0b0b0",
+        Resource.COPPER: "#b87333",
+        Resource.GOLD: "#ffd700",
+        Resource.COAL: "#2f4f4f",
+    }
     width_px = world.width * tile_size
     height_px = world.height * tile_size
     parts = [
@@ -57,7 +69,9 @@ def render_svg(world: World, entities: List[Entity], tile_size: int = 20) -> str
                 r = tile_size // 6
                 cx = x * tile_size + tile_size // 2
                 cy = y * tile_size + tile_size // 2
-                parts.append(f'<circle cx="{cx}" cy="{cy}" r="{r}" fill="#ffd700" />')
+                res = next(iter(tile.resources))
+                rc = res_colors.get(res, "#ffd700")
+                parts.append(f'<circle cx="{cx}" cy="{cy}" r="{r}" fill="{rc}" />')
 
     for e in entities:
         if world.in_bounds(e.x, e.y):

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -1,4 +1,4 @@
-from civsim.entity import Entity
+from civsim.entity import Entity, ReproductionRules
 from civsim.world import World, Resource
 
 
@@ -6,6 +6,7 @@ def test_entity_movement_and_gathering() -> None:
     world = World(width=3, height=3, seed=2)
     entity = Entity(id=1, x=1, y=1)
     tile = world.get_tile(1, 1)
+    tile.resources.clear()
     tile.resources[Resource.WOOD] = 1
 
     entity.move(1, 0, world)
@@ -13,7 +14,7 @@ def test_entity_movement_and_gathering() -> None:
 
     entity.x, entity.y = 1, 1
     entity.gather(world)
-    assert entity.inventory == 1
+    assert entity.inventory.items[Resource.WOOD] == 1
     assert not tile.resources
 
 
@@ -48,3 +49,17 @@ def test_entity_memory_and_relationships() -> None:
 
     e1.take_turn(world)
     assert (1, 1) in e1.memory
+
+
+def test_can_reproduce_rules() -> None:
+    rules = ReproductionRules()
+    entity = Entity(id=1, x=1, y=1)
+    entity.age = rules.min_age
+    entity.needs.energy = rules.energy_min
+    entity.needs.hunger = rules.hunger_max
+    entity.needs.thirst = rules.thirst_max
+    entity.needs.health = rules.health_min
+    assert entity.can_reproduce(rules, 0)
+
+    entity.age = rules.min_age - 1
+    assert not entity.can_reproduce(rules, 0)

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -15,8 +15,31 @@ def test_reproduction_creates_new_entity() -> None:
     world = World(width=3, height=3, seed=2)
     e1 = Entity(id=0, x=1, y=1)
     e2 = Entity(id=1, x=1, y=1)
-    e1.needs.energy = 60
-    e2.needs.energy = 60
+    e1.age = 20
+    e2.age = 20
+    e1.needs.energy = 80
+    e2.needs.energy = 80
     sim = Simulation(world=world, entities=[e1, e2])
     sim.step()
     assert len(sim.entities) == 3
+
+
+def test_entities_do_not_overlap_after_step() -> None:
+    world = World(width=3, height=3, seed=1)
+    e1 = Entity(id=0, x=1, y=1)
+    e2 = Entity(id=1, x=1, y=1)
+    sim = Simulation(world=world, entities=[e1, e2])
+    sim.step()
+    positions = {(e.x, e.y) for e in sim.entities}
+    assert len(positions) == len(sim.entities)
+
+
+def test_reproduction_requires_conditions() -> None:
+    world = World(width=3, height=3, seed=3)
+    e1 = Entity(id=0, x=1, y=1)
+    e2 = Entity(id=1, x=1, y=1)
+    e1.age = 5  # below threshold
+    e2.age = 5
+    sim = Simulation(world=world, entities=[e1, e2])
+    sim.step()
+    assert len(sim.entities) == 2


### PR DESCRIPTION
## Summary
- implement Inventory dataclass for per-resource counts
- color-code resource nodes in UI and SVG rendering
- show tile resource details when clicked
- make wood nodes single-use by reducing initial amount
- update tests for new inventory structure

## Testing
- `black --check . --line-length 88`
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68460e350ab4832493b4ec20bf5c163b