### PR TITLE
Expand world map generation with regions and elevation

### DIFF
--- a/src/civsim/ui.py
+++ b/src/civsim/ui.py
@@ -108,6 +108,7 @@ class SimulationUI:
             Biome.FOREST: "#228b22",
             Biome.DESERT: "#e0c469",
             Biome.WATER: "#1e90ff",
+            Biome.MOUNTAIN: "#888888",
         }
         res_colors = {
             Resource.WOOD: "#8b4513",

--- a/src/civsim/visualize.py
+++ b/src/civsim/visualize.py
@@ -17,6 +17,7 @@ def render_ascii(world: World, entities: List[Entity]) -> str:
             Biome.FOREST: "F",
             Biome.DESERT: "D",
             Biome.WATER: "~",
+            Biome.MOUNTAIN: "^",
         }[biome]
 
     grid = [
@@ -39,6 +40,7 @@ def render_svg(world: World, entities: List[Entity], tile_size: int = 20) -> str
         Biome.FOREST: "#228b22",
         Biome.DESERT: "#e0c469",
         Biome.WATER: "#1e90ff",
+        Biome.MOUNTAIN: "#888888",
     }
     res_colors = {
         Resource.WOOD: "#8b4513",
@@ -96,6 +98,7 @@ def render_vision_ascii(world: World, entity: Entity) -> str:
             Biome.FOREST: "F",
             Biome.DESERT: "D",
             Biome.WATER: "~",
+            Biome.MOUNTAIN: "^",
         }[biome]
 
     grid = [
@@ -125,6 +128,7 @@ def render_memory_ascii(world: World, entity: Entity) -> str:
             Biome.FOREST: "F",
             Biome.DESERT: "D",
             Biome.WATER: "~",
+            Biome.MOUNTAIN: "^",
         }[biome]
 
     grid = [

--- a/src/civsim/world.py
+++ b/src/civsim/world.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from enum import Enum
+import math
 import random
 from typing import List
 
@@ -15,6 +16,7 @@ class Biome(Enum):
     FOREST = "forest"
     DESERT = "desert"
     WATER = "water"
+    MOUNTAIN = "mountain"
 
 
 class Resource(Enum):
@@ -37,6 +39,7 @@ class Tile:
     """A single map tile."""
 
     biome: Biome
+    elevation: float = 0.0
     resources: dict[Resource, int] = field(default_factory=dict)
 
 
@@ -53,38 +56,82 @@ class World:
         height: int,
         seed: int | None = None,
         biome_scale: int = 5,
-        resource_scale: int = 3,
+        resource_scale: int = 8,
+        region_size: int = 32,
     ) -> None:
         self.width = width
         self.height = height
+        self.region_size = max(
+            1,
+            min(
+                region_size, max(1, width // biome_scale), max(1, height // biome_scale)
+            ),
+        )
         rng = random.Random(seed)
 
         self.tiles = [
             [Tile(biome=Biome.PLAINS) for _ in range(width)] for _ in range(height)
         ]
 
-        # generate a temperature map to guide biome placement
+        reg_w = math.ceil(width / self.region_size)
+        reg_h = math.ceil(height / self.region_size)
+
         temps = [
-            min(1.0, max(0.0, y / height + rng.uniform(-0.1, 0.1)))
-            for y in range(height)
+            min(1.0, max(0.0, ry / reg_h + rng.uniform(-0.1, 0.1)))
+            for ry in range(reg_h)
         ]
 
-        for y in range(height):
-            for x in range(width):
-                neighbors = []
-                if x > 0:
-                    neighbors.append(self.tiles[y][x - 1].biome)
-                if y > 0:
-                    neighbors.append(self.tiles[y - 1][x].biome)
+        region_biomes: List[List[Biome]] = [
+            [Biome.PLAINS for _ in range(reg_w)] for _ in range(reg_h)
+        ]
+        region_elev: List[List[float]] = [
+            [rng.random() for _ in range(reg_w)] for _ in range(reg_h)
+        ]
 
+        for ry in range(reg_h):
+            for rx in range(reg_w):
+                neighbors = []
+                if rx > 0:
+                    neighbors.append(region_biomes[ry][rx - 1])
+                if ry > 0:
+                    neighbors.append(region_biomes[ry - 1][rx])
+
+                base_elev = region_elev[ry][rx]
                 if neighbors and rng.random() < 0.6:
                     biome = rng.choice(neighbors)
                 else:
-                    biome = self._biome_from_temperature(temps[y], rng)
+                    biome = self._biome_from_climate(temps[ry], base_elev, rng)
 
-                self.tiles[y][x].biome = biome
+                region_biomes[ry][rx] = biome
 
-        # place resource nodes in a finer subgrid
+                for y in range(
+                    ry * self.region_size, min((ry + 1) * self.region_size, height)
+                ):
+                    for x in range(
+                        rx * self.region_size, min((rx + 1) * self.region_size, width)
+                    ):
+                        elev = min(1.0, max(0.0, base_elev + rng.uniform(-0.05, 0.05)))
+                        self.tiles[y][x].elevation = elev
+                        self.tiles[y][x].biome = (
+                            Biome.MOUNTAIN if elev > 0.85 else biome
+                        )
+
+        needed = {Biome.PLAINS, Biome.FOREST, Biome.DESERT, Biome.WATER}
+        present = {tile.biome for row in self.tiles for tile in row}
+        for missing in needed - present:
+            x = rng.randrange(width)
+            y = rng.randrange(height)
+            self.tiles[y][x].biome = missing
+
+        for y in range(height):
+            for x in range(width):
+                tile = self.tiles[y][x]
+                if tile.biome == Biome.FOREST and rng.random() < 0.7:
+                    amt = rng.randint(3, 7)
+                    tile.resources[Resource.WOOD] = (
+                        tile.resources.get(Resource.WOOD, 0) + amt
+                    )
+
         for ry in range(0, height, resource_scale):
             for rx in range(0, width, resource_scale):
                 tx = rng.randrange(rx, min(rx + resource_scale, width))
@@ -109,7 +156,27 @@ class World:
         return self.tiles[y][x]
 
     def _biome_from_temperature(self, temp: float, rng: random.Random) -> Biome:
-        """Return a biome type influenced by temperature."""
+        """Return a biome type influenced by temperature (legacy)."""
+
+        if temp < 0.3:
+            choices = [Biome.FOREST, Biome.PLAINS]
+        elif temp < 0.6:
+            choices = [Biome.PLAINS, Biome.FOREST, Biome.DESERT]
+        else:
+            choices = [Biome.DESERT, Biome.PLAINS]
+
+        if rng.random() < 0.05:
+            choices.append(Biome.WATER)
+
+        return rng.choice(choices)
+
+    def _biome_from_climate(
+        self, temp: float, elevation: float, rng: random.Random
+    ) -> Biome:
+        """Return a biome given temperature and elevation."""
+
+        if elevation > 0.8:
+            return Biome.MOUNTAIN
 
         if temp < 0.3:
             choices = [Biome.FOREST, Biome.PLAINS]
@@ -128,31 +195,41 @@ class World:
 
         distribution = {
             Biome.FOREST: [
-                (Resource.WOOD, 0.6),
-                (Resource.ANIMAL, 0.2),
+                (Resource.WOOD, 0.9),
+                (Resource.ANIMAL, 0.3),
                 (Resource.STONE, 0.1),
-                (Resource.CLAY, 0.1),
+                (None, 0.2),
             ],
             Biome.PLAINS: [
                 (Resource.FOOD, 0.3),
                 (Resource.WATER, 0.2),
                 (Resource.ANIMAL, 0.2),
-                (Resource.WOOD, 0.15),
+                (Resource.WOOD, 0.1),
                 (Resource.STONE, 0.1),
                 (Resource.IRON, 0.05),
+                (None, 0.3),
             ],
             Biome.DESERT: [
-                (Resource.STONE, 0.3),
+                (Resource.STONE, 0.4),
                 (Resource.CLAY, 0.3),
+                (Resource.IRON, 0.1),
+                (Resource.COPPER, 0.05),
+                (Resource.COAL, 0.05),
+                (Resource.GOLD, 0.05),
+                (Resource.WATER, 0.05),
+                (None, 0.4),
+            ],
+            Biome.MOUNTAIN: [
+                (Resource.STONE, 0.5),
                 (Resource.IRON, 0.15),
                 (Resource.COPPER, 0.1),
                 (Resource.COAL, 0.1),
                 (Resource.GOLD, 0.05),
-                (Resource.WATER, 0.05),
+                (None, 0.5),
             ],
             Biome.WATER: [
-                (Resource.WATER, 0.5),
-                (Resource.ANIMAL, 0.5),
+                (Resource.WATER, 0.6),
+                (Resource.ANIMAL, 0.4),
             ],
         }
 
@@ -164,7 +241,7 @@ class World:
         upto = 0.0
         for res, weight in choices:
             if upto + weight >= r:
-                return res
+                return res  # type: ignore[return-value]
             upto += weight
         return None
 
@@ -172,16 +249,16 @@ class World:
         """Return an amount for the given resource type."""
 
         ranges = {
-            Resource.WOOD: (1, 1),
+            Resource.WOOD: (3, 7),
             Resource.ANIMAL: (1, 3),
             Resource.STONE: (2, 5),
             Resource.CLAY: (2, 5),
             Resource.FOOD: (2, 6),
             Resource.WATER: (1, 3),
-            Resource.IRON: (1, 4),
-            Resource.COPPER: (1, 3),
-            Resource.COAL: (1, 3),
-            Resource.GOLD: (1, 2),
+            Resource.IRON: (1, 3),
+            Resource.COPPER: (1, 2),
+            Resource.COAL: (1, 2),
+            Resource.GOLD: (1, 1),
         }
         low, high = ranges.get(res, (1, 3))
         return rng.randint(low, high)


### PR DESCRIPTION
## Summary
- add `MOUNTAIN` biome and elevation to tiles
- generate biomes using regional grid with elevation-based mountains
- ensure required biomes appear in small maps
- make forest tiles spawn wood resources densely
- make ore resources rarer and tweak quantities
- support new biome colours and chars in UI and visualisation

## Testing
- `black .`
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684618ca750c832498f449be4605acba