### PR TITLE
Introduce impassable resource tiles and richer AI

### DIFF
--- a/src/civsim/__init__.py
+++ b/src/civsim/__init__.py
@@ -3,6 +3,7 @@
 from .world import World, Biome
 from .entity import Entity, ReproductionRules
 from .simulation import Simulation
+from .actions import Action, MoveAction, MoveToAction, GatherAction, RestAction
 from .visualize import (
     render_ascii,
     render_svg,
@@ -17,6 +18,11 @@ __all__ = [
     "Entity",
     "ReproductionRules",
     "Simulation",
+    "Action",
+    "MoveAction",
+    "MoveToAction",
+    "GatherAction",
+    "RestAction",
     "render_ascii",
     "render_svg",
     "render_vision_ascii",

--- a/src/civsim/actions.py
+++ b/src/civsim/actions.py
@@ -1,0 +1,133 @@
+"""Action system for entity decisions and multi-tick tasks."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List, Optional, Tuple, TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - used for type hints only
+    from .entity import Entity
+
+from .world import World
+
+
+class Action:
+    """Base class for an action executed over one or more ticks."""
+
+    finished: bool = False
+
+    def start(self, entity: "Entity", world: World) -> None:
+        """Prepare the action."""
+
+    def step(
+        self, entity: "Entity", world: World, occupied: set[Tuple[int, int]]
+    ) -> None:
+        """Perform one tick of the action."""
+        self.finished = True
+
+
+@dataclass
+class MoveAction(Action):
+    """Move one step if possible."""
+
+    dx: int
+    dy: int
+
+    def step(
+        self, entity: "Entity", world: World, occupied: set[Tuple[int, int]]
+    ) -> None:
+        if entity.move(self.dx, self.dy, world, occupied):
+            self.finished = True
+        else:
+            self.finished = True
+
+
+@dataclass
+class MoveToAction(Action):
+    """Pathfind to a specific tile over multiple ticks."""
+
+    target: Tuple[int, int]
+    path: List[Tuple[int, int]] = field(default_factory=list)
+
+    def start(self, entity: "Entity", world: World) -> None:
+        self._rebuild_path(entity, world)
+
+    def _rebuild_path(self, entity: "Entity", world: World) -> None:
+        self.path = self._bfs(entity, world)
+
+    def _bfs(self, entity: "Entity", world: World) -> List[Tuple[int, int]]:
+        start = (entity.x, entity.y)
+        goal = self.target
+        if start == goal:
+            return []
+        frontier = [start]
+        came_from: dict[Tuple[int, int], Optional[Tuple[int, int]]] = {start: None}
+        while frontier:
+            x, y = frontier.pop(0)
+            if (x, y) == goal:
+                break
+            for dx, dy in ((1, 0), (-1, 0), (0, 1), (0, -1)):
+                nx, ny = x + dx, y + dy
+                if not world.in_bounds(nx, ny):
+                    continue
+                if (nx, ny) in came_from:
+                    continue
+                if not world.get_tile(nx, ny).walkable and (nx, ny) != goal:
+                    continue
+                came_from[(nx, ny)] = (x, y)
+                frontier.append((nx, ny))
+        else:
+            return []
+        cur = goal
+        path_rev = []
+        while cur != start:
+            path_rev.append(cur)
+            cur = came_from[cur]
+            if cur is None:
+                break
+        path_rev.reverse()
+        return path_rev
+
+    def step(
+        self, entity: "Entity", world: World, occupied: set[Tuple[int, int]]
+    ) -> None:
+        if not self.path:
+            self.finished = True
+            return
+        next_pos = self.path[0]
+        dx = next_pos[0] - entity.x
+        dy = next_pos[1] - entity.y
+        if entity.move(dx, dy, world, occupied):
+            self.path.pop(0)
+            if not self.path:
+                self.finished = True
+        else:
+            self._rebuild_path(entity, world)
+            if not self.path:
+                self.finished = True
+
+
+class GatherAction(Action):
+    """Gather a resource from the current tile."""
+
+    def step(
+        self, entity: "Entity", world: World, occupied: set[Tuple[int, int]]
+    ) -> None:
+        entity.gather(world)
+        self.finished = True
+
+
+class RestAction(Action):
+    """Rest until energy is above a threshold."""
+
+    threshold: int = 50
+
+    def step(
+        self, entity: "Entity", world: World, occupied: set[Tuple[int, int]]
+    ) -> None:
+        if entity.needs.energy >= self.threshold:
+            self.finished = True
+            return
+        entity.rest()
+        if entity.needs.energy >= self.threshold:
+            self.finished = True

--- a/src/civsim/entity.py
+++ b/src/civsim/entity.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 import random
 from dataclasses import dataclass, field
-from typing import Dict, Set, Tuple
+from typing import Dict, Optional, Set, Tuple
 
-from .world import World, Resource
+from .world import World, Resource, Tile
+from .actions import Action, GatherAction, MoveAction, MoveToAction, RestAction
 
 
 @dataclass
@@ -19,6 +20,7 @@ class Needs:
     thirst: int = 0
     energy: int = 100
     morale: int = 50
+    loneliness: int = 0
     injuries: int = 0
 
 
@@ -80,6 +82,7 @@ class Entity:
     memory: Set[Tuple[int, int]] = field(default_factory=set)
     relationships: Dict[int, str] = field(default_factory=dict)
     last_reproduced: int = -9999
+    current_action: Optional[Action] = None
 
     def perceive(self, world: World) -> None:
         """Add visible tiles to memory based on perception range."""
@@ -104,22 +107,65 @@ class Entity:
             occupied = set()
 
         nx, ny = self.x + dx, self.y + dy
-        if world.in_bounds(nx, ny) and (nx, ny) not in occupied:
+        if (
+            world.in_bounds(nx, ny)
+            and (nx, ny) not in occupied
+            and world.get_tile(nx, ny).walkable
+        ):
             self.x, self.y = nx, ny
             return True
         return False
 
-    def gather(self, world: World) -> None:
-        """Gather one resource from the current tile if available."""
+    def remembered_tile_with_resource(
+        self, world: World, resource: Resource
+    ) -> Tuple[int, int] | None:
+        """Return coordinates of a remembered tile containing the resource."""
 
-        tile = world.get_tile(self.x, self.y)
-        if not tile.resources:
+        for x, y in sorted(self.memory):
+            if not world.in_bounds(x, y):
+                continue
+            tile = world.get_tile(x, y)
+            if resource in tile.resources:
+                return x, y
+        return None
+
+    def remembered_adjacent_tile_for_resource(
+        self, world: World, resource: Resource
+    ) -> Tuple[int, int] | None:
+        """Return a walkable tile adjacent to a remembered resource."""
+
+        for x, y in self.memory:
+            if not world.in_bounds(x, y):
+                continue
+            tile = world.get_tile(x, y)
+            if resource not in tile.resources:
+                continue
+            for dx, dy in ((1, 0), (-1, 0), (0, 1), (0, -1)):
+                nx, ny = x + dx, y + dy
+                if world.in_bounds(nx, ny) and world.get_tile(nx, ny).walkable:
+                    return nx, ny
+        return None
+
+    def gather(self, world: World) -> None:
+        """Gather a resource from an adjacent non-walkable tile."""
+
+        sources: list[Tuple[Tile, Tuple[int, int]]] = []
+        for dx, dy in ((1, 0), (-1, 0), (0, 1), (0, -1)):
+            nx, ny = self.x + dx, self.y + dy
+            if not world.in_bounds(nx, ny):
+                continue
+            t = world.get_tile(nx, ny)
+            if t.resources:
+                sources.append((t, (nx, ny)))
+        if not sources:
             return
 
+        tile, _ = random.choice(sources)
         res = random.choice(list(tile.resources.keys()))
         tile.resources[res] -= 1
         if tile.resources[res] <= 0:
             del tile.resources[res]
+            tile.walkable = True
         self.inventory.add(res)
         if self.needs.hunger > 0:
             self.needs.hunger = max(0, self.needs.hunger - 1)
@@ -132,11 +178,36 @@ class Entity:
         self.needs.energy = min(100, self.needs.energy + 20)
         self.needs.hunger += 1
         self.needs.thirst += 1
+        self.needs.morale = min(100, self.needs.morale + 1)
 
     def add_relationship(self, other: "Entity", kind: str) -> None:
         """Record a relationship with another entity."""
 
         self.relationships[other.id] = kind
+
+    def plan_action(self, world: World) -> Action:
+        """Select the next action based on needs and memory."""
+
+        if self.needs.energy <= 20:
+            return RestAction()
+
+        directions = [(1, 0), (-1, 0), (0, 1), (0, -1)]
+        for dx, dy in directions:
+            nx, ny = self.x + dx, self.y + dy
+            if world.in_bounds(nx, ny) and world.get_tile(nx, ny).resources:
+                return GatherAction()
+
+        if self.needs.hunger >= 10:
+            loc = self.remembered_adjacent_tile_for_resource(world, Resource.FOOD)
+            if loc:
+                return MoveToAction(target=loc)
+
+        if self.needs.loneliness >= 8:
+            dx, dy = random.choice(directions)
+            return MoveAction(dx, dy)
+
+        dx, dy = random.choice(directions)
+        return MoveAction(dx, dy)
 
     def can_reproduce(
         self,
@@ -187,7 +258,7 @@ class Entity:
     def take_turn(
         self, world: World, occupied: Set[Tuple[int, int]] | None = None
     ) -> None:
-        """Perform a simple turn: update needs then act."""
+        """Update needs, decide on an action, and perform it."""
 
         if occupied is None:
             occupied = set()
@@ -196,6 +267,11 @@ class Entity:
         self.needs.hunger += 1
         self.needs.thirst += 1
         self.needs.energy -= 1
+        directions = [(1, 0), (-1, 0), (0, 1), (0, -1)]
+        if any((self.x + dx, self.y + dy) in occupied for dx, dy in directions):
+            self.needs.loneliness = max(0, self.needs.loneliness - 2)
+        else:
+            self.needs.loneliness += 1
 
         self.memory.add((self.x, self.y))
         self.perceive(world)
@@ -204,18 +280,22 @@ class Entity:
             self.needs.health = max(0, self.needs.health - 5)
             self.needs.injuries += 1
 
+        if (
+            self.needs.hunger > 10
+            or self.needs.thirst > 10
+            or self.needs.loneliness > 5
+        ):
+            self.needs.morale = max(0, self.needs.morale - 1)
+        else:
+            self.needs.morale = min(100, self.needs.morale + 1)
+
         if self.age >= self.max_age:
             self.needs.health = 0
 
-        if self.needs.energy <= 0:
-            self.rest()
-            return
+        if self.current_action is None or self.current_action.finished:
+            self.current_action = self.plan_action(world)
+            self.current_action.start(self, world)
 
-        directions = [(1, 0), (-1, 0), (0, 1), (0, -1), (0, 0)]
-        random.shuffle(directions)
-        for dx, dy in directions:
-            if self.move(dx, dy, world, occupied):
-                break
+        self.current_action.step(self, world, occupied)
         self.memory.add((self.x, self.y))
         self.perceive(world)
-        self.gather(world)

--- a/src/civsim/world.py
+++ b/src/civsim/world.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from enum import Enum
-import math
 import random
 from typing import List
 
@@ -41,6 +40,7 @@ class Tile:
     biome: Biome
     elevation: float = 0.0
     resources: dict[Resource, int] = field(default_factory=dict)
+    walkable: bool = True
 
 
 class World:
@@ -109,7 +109,9 @@ class World:
                 temp = temp_map[y][x]
                 moist = moist_map[y][x]
                 biome = self._biome_from_climate(temp, moist, rng)
-                self.tiles[y][x].biome = biome
+                tile = self.tiles[y][x]
+                tile.biome = biome
+                tile.walkable = biome not in (Biome.WATER, Biome.MOUNTAIN)
 
         # second pass to smooth biome edges
         for _ in range(2):
@@ -141,6 +143,7 @@ class World:
                     continue
                 amount = self._resource_amount(res_type, rng)
                 tile.resources[res_type] = tile.resources.get(res_type, 0) + amount
+                tile.walkable = False
 
     def in_bounds(self, x: int, y: int) -> bool:
         """Return True if the coordinates are inside the map."""

--- a/tests/test_world.py
+++ b/tests/test_world.py
@@ -7,3 +7,14 @@ def test_world_generation() -> None:
     assert world.height == 20
     biomes = {tile.biome for row in world.tiles for tile in row}
     assert {Biome.PLAINS, Biome.FOREST, Biome.DESERT, Biome.WATER}.issubset(biomes)
+
+
+def test_resource_tiles_not_walkable() -> None:
+    world = World(width=10, height=10, seed=2)
+    has_resource = False
+    for row in world.tiles:
+        for tile in row:
+            if tile.resources:
+                has_resource = True
+                assert not tile.walkable
+    assert has_resource


### PR DESCRIPTION
## Summary
- make resource nodes non-walkable
- gather resources from adjacent tiles and free tiles when depleted
- add loneliness need and morale adjustments
- pathfinding and movement respect walkability
- update decision logic to consider new needs
- expand tests for new behaviour

## Testing
- `black --check .`
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684622bdd61883248273d4e30dc3a4d9