### PR TITLE
Improve entity resource-seeking behavior

### DIFF
--- a/src/civsim/entity.py
+++ b/src/civsim/entity.py
@@ -206,8 +206,8 @@ class Entity:
         """Recover energy while increasing hunger and thirst."""
 
         self.needs.energy = min(100, self.needs.energy + 20)
-        self.needs.hunger += 1
-        self.needs.thirst += 1
+        self.needs.hunger += 0.5
+        self.needs.thirst += 0.5
         self.needs.morale = min(100, self.needs.morale + 1)
 
     def add_relationship(self, other: "Entity", kind: str) -> None:
@@ -244,12 +244,15 @@ class Entity:
             if world.in_bounds(nx, ny) and world.get_tile(nx, ny).resources:
                 return GatherAction()
 
-        if self.needs.thirst >= 8:
+        if self.needs.thirst >= 50 and self.inventory.items.get(Resource.WATER, 0) == 0:
             loc = self.remembered_adjacent_tile_for_resource(world, Resource.WATER)
             if loc:
                 return MoveToAction(target=loc)
 
-        if self.needs.hunger >= 8:
+        if self.needs.hunger >= 50 and not any(
+            self.inventory.items.get(res, 0) > 0
+            for res in (Resource.MEAT, Resource.BERRIES)
+        ):
             for res in (Resource.ANIMAL, Resource.BERRY_BUSH):
                 loc = self.remembered_adjacent_tile_for_resource(world, res)
                 if loc:
@@ -317,8 +320,8 @@ class Entity:
             occupied = set()
 
         self.age += 1
-        self.needs.hunger += 1
-        self.needs.thirst += 1
+        self.needs.hunger += 0.5
+        self.needs.thirst += 0.5
         self.needs.energy -= 1
         directions = [(1, 0), (-1, 0), (0, 1), (0, -1)]
         if any((self.x + dx, self.y + dy) in occupied for dx, dy in directions):
@@ -333,12 +336,6 @@ class Entity:
             regen += 1
         if regen:
             self.needs.health = min(self.needs.max_health, self.needs.health + regen)
-        directions = [(1, 0), (-1, 0), (0, 1), (0, -1)]
-        if any((self.x + dx, self.y + dy) in occupied for dx, dy in directions):
-            self.needs.loneliness = max(0, self.needs.loneliness - 2)
-        else:
-            self.needs.loneliness += 1
-
         self.memory.add((self.x, self.y))
         self.perceive(world)
 

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -23,8 +23,8 @@ def test_entity_needs_update_and_rest() -> None:
     entity.needs.energy = 1
 
     entity.take_turn(world)
-    assert entity.needs.hunger == 2
-    assert entity.needs.thirst == 2
+    assert entity.needs.hunger == 1.0
+    assert entity.needs.thirst == 1.0
     assert entity.needs.energy == 20  # rested when energy depleted
 
 
@@ -85,7 +85,7 @@ def test_entity_moves_to_remembered_resource() -> None:
 
     e = Entity(id=1, x=0, y=0)
     e.memory.update({(0, 0), (1, 0), (2, 0)})
-    e.needs.hunger = 15
+    e.needs.hunger = 55
 
     for _ in range(2):
         e.take_turn(world)


### PR DESCRIPTION
## Summary
- slow hunger and thirst accumulation in `take_turn`
- lower increments while resting
- look for food or water when hunger/thirst reach 50 and none is in inventory
- remove duplicate loneliness update
- adjust tests for new thresholds

## Testing
- `black . --check`
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684630b7d7fc8324be276b03f43ffa39