### PR TITLE
Implement collaborative construction

### DIFF
--- a/run.py
+++ b/run.py
@@ -1,10 +1,11 @@
 """Interactive demo script for the civilization simulator."""
 
-from civsim import Entity, Simulation, World, SimulationUI
+from civsim import Entity, Simulation, World, SimulationUI, Building
 
 
 def main() -> None:
     world = World(width=120, height=80, seed=42)
+    world.place_building(Building(id=0, x=10, y=10, width=4, height=3, name="house"))
     entities = [Entity(id=i, x=world.width // 2, y=world.height // 2) for i in range(5)]
     sim = Simulation(world=world, entities=entities)
     ui = SimulationUI(sim, ticks_per_second=2)

--- a/src/civsim/__init__.py
+++ b/src/civsim/__init__.py
@@ -1,6 +1,6 @@
 """Convenience exports for the civsim package."""
 
-from .world import World, Biome
+from .world import World, Biome, Building
 from .entity import Entity, ReproductionRules
 from .simulation import Simulation
 from .actions import (
@@ -22,6 +22,7 @@ from .ui import SimulationUI
 __all__ = [
     "World",
     "Biome",
+    "Building",
     "Entity",
     "ReproductionRules",
     "Simulation",

--- a/src/civsim/visualize.py
+++ b/src/civsim/visualize.py
@@ -21,7 +21,14 @@ def render_ascii(world: World, entities: List[Entity]) -> str:
         }[biome]
 
     grid = [
-        [tile_char(world.tiles[y][x].biome) for x in range(world.width)]
+        [
+            (
+                "B"
+                if world.tiles[y][x].building_id is not None
+                else tile_char(world.tiles[y][x].biome)
+            )
+            for x in range(world.width)
+        ]
         for y in range(world.height)
     ]
 
@@ -83,6 +90,10 @@ def render_svg(world: World, entities: List[Entity], tile_size: int = 20) -> str
             parts.append(
                 f'<rect x="{x*tile_size}" y="{y*tile_size}" width="{tile_size}" height="{tile_size}" fill="{color}" />'
             )
+            if tile.building_id is not None:
+                parts.append(
+                    f'<rect x="{x*tile_size}" y="{y*tile_size}" width="{tile_size}" height="{tile_size}" fill="#666666" opacity="0.6" />'
+                )
             if tile.resources:
                 r = tile_size // 6
                 cx = x * tile_size + tile_size // 2

--- a/tests/test_buildings.py
+++ b/tests/test_buildings.py
@@ -1,0 +1,87 @@
+from civsim.world import World, Building, Blueprint, Resource
+from civsim.entity import Entity
+from civsim.actions import BuildAction
+from civsim.simulation import Simulation
+
+
+def test_place_building_blocks_tiles() -> None:
+    world = World(width=5, height=5, seed=1)
+    for dy in range(3):
+        for dx in range(2):
+            tile = world.get_tile(1 + dx, 1 + dy)
+            tile.resources.clear()
+            tile.walkable = True
+    b = Building(id=0, x=1, y=1, width=2, height=3, name="hut")
+    assert world.place_building(b)
+    for dy in range(3):
+        for dx in range(2):
+            tile = world.get_tile(1 + dx, 1 + dy)
+            assert not tile.walkable
+            assert tile.building_id == b.id
+
+
+def test_cannot_overlap_building() -> None:
+    world = World(width=5, height=5, seed=2)
+    b1 = Building(id=0, x=0, y=0, width=2, height=2)
+    assert world.place_building(b1)
+    b2 = Building(id=1, x=1, y=1, width=2, height=2)
+    assert not world.place_building(b2)
+
+
+def test_build_action_places_building() -> None:
+    world = World(width=4, height=4, seed=3)
+    for dy in range(2):
+        for dx in range(2):
+            tile = world.get_tile(1 + dx, 1 + dy)
+            tile.resources.clear()
+            tile.walkable = True
+    e = Entity(id=1, x=1, y=1)
+    e.inventory.add(Resource.WOOD, 4)
+    bp = Blueprint(
+        name="house",
+        width=2,
+        height=2,
+        cost={Resource.WOOD: 4},
+        bonuses={"morale": 5},
+        occupant_limit=2,
+        build_time=3,
+    )
+    action = BuildAction(bp, 1, 1)
+    e.current_action = action
+    action.start(e, world)
+    sim = Simulation(world=world, entities=[e])
+    for _ in range(bp.build_time):
+        sim.step()
+    assert any(b.name == "house" for b in world.buildings)
+    assert e.skills.construction == 1
+    assert e.home_id is not None
+
+
+def test_group_building_speeds_up() -> None:
+    world = World(width=4, height=4, seed=4)
+    for dy in range(2):
+        for dx in range(2):
+            tile = world.get_tile(1 + dx, 1 + dy)
+            tile.resources.clear()
+            tile.walkable = True
+    e1 = Entity(id=1, x=1, y=1)
+    e1.inventory.add(Resource.WOOD, 4)
+    e2 = Entity(id=2, x=1, y=1)
+    bp = Blueprint(
+        name="house",
+        width=2,
+        height=2,
+        cost={Resource.WOOD: 4},
+        bonuses={"morale": 5},
+        occupant_limit=2,
+        build_time=4,
+    )
+    act = BuildAction(bp, 1, 1)
+    e1.current_action = act
+    act.start(e1, world)
+    sim = Simulation(world=world, entities=[e1, e2])
+    for _ in range(bp.build_time):
+        sim.step()
+    house = next((b for b in world.buildings if b.name == "house"), None)
+    assert house is not None
+    assert len(house.occupant_ids) == 2

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -82,6 +82,10 @@ def test_entity_moves_to_remembered_resource() -> None:
     tile.resources.clear()
     tile.resources[Resource.BERRY_BUSH] = 1
     tile.walkable = False
+    world.get_tile(0, 0).resources.clear()
+    mid = world.get_tile(1, 0)
+    mid.resources.clear()
+    mid.walkable = True
 
     e = Entity(id=1, x=0, y=0)
     e.memory.update({(0, 0), (1, 0), (2, 0)})

--- a/tests/test_households.py
+++ b/tests/test_households.py
@@ -1,0 +1,34 @@
+from civsim.world import World, Building
+from civsim.entity import Entity
+from civsim.simulation import Simulation
+
+
+def test_house_capacity_and_memory_sharing() -> None:
+    world = World(width=5, height=5, seed=1)
+    for dy in range(2):
+        for dx in range(2):
+            tile = world.get_tile(dx, dy)
+            tile.resources.clear()
+            tile.walkable = True
+    house = Building(id=0, x=0, y=0, width=2, height=2, name="house", occupant_limit=1)
+    assert world.place_building(house)
+    e1 = Entity(id=1, x=0, y=0)
+    e2 = Entity(id=2, x=0, y=0)
+    assert e1.bind_to_house(house)
+    assert not e2.bind_to_house(house)
+
+    house2 = Building(id=1, x=3, y=0, width=2, height=2, name="house", occupant_limit=2)
+    for dy in range(2):
+        for dx in range(2):
+            tile = world.get_tile(3 + dx, dy)
+            tile.resources.clear()
+            tile.walkable = True
+    assert world.place_building(house2)
+    e3 = Entity(id=3, x=3, y=0)
+    e4 = Entity(id=4, x=3, y=0)
+    assert e3.bind_to_house(house2)
+    assert e4.bind_to_house(house2)
+    e3.memory.add((4, 4))
+    sim = Simulation(world=world, entities=[e1, e2, e3, e4])
+    sim._share_house_memory()
+    assert (4, 4) in e4.memory


### PR DESCRIPTION
## Summary
- add `ConstructionSite` for multi-entity building projects
- extend `Blueprint` with `build_time`
- implement site start/advance logic in `World`
- rework `BuildAction` to use construction sites
- let entities join nearby projects
- finalize construction and reward builders in `Simulation`
- update tests for new behaviour

## Testing
- `black --check .`
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68463ed5228883249000079807e81382