### PR TITLE
Reduce starvation damage

### DIFF
--- a/src/civsim/entity.py
+++ b/src/civsim/entity.py
@@ -380,7 +380,7 @@ class Entity:
         self.perceive(world)
 
         if self.needs.hunger >= 20 or self.needs.thirst >= 20:
-            self.needs.health = max(0, self.needs.health - 5)
+            self.needs.health = max(0, self.needs.health - 0.25)
             self.needs.injuries += 1
 
         if (

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -53,4 +53,5 @@ def test_entities_die_and_are_removed() -> None:
     e.needs.thirst = 20
     sim = Simulation(world=world, entities=[e])
     sim.step()
-    assert not sim.entities
+    assert len(sim.entities) == 1
+    assert sim.entities[0].needs.health == 4.75


### PR DESCRIPTION
## Summary
- reduce health loss from hunger or thirst
- adjust simulation test to expect slower starvation

## Testing
- `black --check .`
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6846527847bc8324a7a978069a5fae12