### PR TITLE
Reduce starvation damage

### DIFF
--- a/scripts/tune_thresholds.py
+++ b/scripts/tune_thresholds.py
@@ -1,0 +1,67 @@
+import statistics
+from civsim import World, Simulation, Entity
+from civsim.actions import RestAction, ConsumeAction, MoveToAction
+from civsim.world import Resource
+
+# Parameter ranges
+consume_levels = [8, 12, 16]
+gather_levels = [30, 40, 50]
+
+
+class TestEntity(Entity):
+    consume_level = 12
+    gather_level = 50
+
+    def plan_action(self, world):
+        if self.needs.energy <= 20:
+            return RestAction()
+        if self.needs.health < 30:
+            if (
+                self.needs.thirst > 5
+                and self.inventory.items.get(Resource.WATER, 0) > 0
+            ):
+                return ConsumeAction(Resource.WATER)
+            for food in (Resource.MEAT, Resource.BERRIES):
+                if self.needs.hunger > 5 and self.inventory.items.get(food, 0) > 0:
+                    return ConsumeAction(food)
+        if (
+            self.needs.thirst >= self.consume_level
+            and self.inventory.items.get(Resource.WATER, 0) > 0
+        ):
+            return ConsumeAction(Resource.WATER)
+        if self.needs.hunger >= self.consume_level:
+            for food in (Resource.MEAT, Resource.BERRIES):
+                if self.inventory.items.get(food, 0) > 0:
+                    return ConsumeAction(food)
+        if (
+            self.needs.thirst >= self.gather_level
+            and self.inventory.items.get(Resource.WATER, 0) == 0
+        ):
+            loc = self.remembered_adjacent_tile_for_resource(world, Resource.WATER)
+            if loc:
+                return MoveToAction(target=loc)
+        if self.needs.hunger >= self.gather_level and not any(
+            self.inventory.items.get(res, 0) > 0
+            for res in (Resource.MEAT, Resource.BERRIES)
+        ):
+            for res in (Resource.ANIMAL, Resource.BERRY_BUSH):
+                loc = self.remembered_adjacent_tile_for_resource(world, res)
+                if loc:
+                    return MoveToAction(target=loc)
+        return super().plan_action(world)
+
+
+results = {}
+for c in consume_levels:
+    for g in gather_levels:
+        world = World(width=20, height=20, seed=4, resource_scale=4)
+        entities = [TestEntity(id=i, x=10, y=10) for i in range(5)]
+        for e in entities:
+            e.consume_level = c
+            e.gather_level = g
+        sim = Simulation(world=world, entities=entities)
+        for _ in range(50):
+            sim.step()
+        avg_hunger = statistics.mean(e.needs.hunger for e in sim.entities)
+        results[(c, g)] = avg_hunger
+print(results)

--- a/src/civsim/entity.py
+++ b/src/civsim/entity.py
@@ -212,6 +212,32 @@ class Entity:
         elif resource is Resource.MEAT:
             self.needs.hunger = max(0, self.needs.hunger - 7)
 
+    def step_toward_unexplored(self, world: World) -> MoveAction | None:
+        """Return a move action biased toward unexplored territory."""
+
+        directions = [(1, 0), (-1, 0), (0, 1), (0, -1)]
+        best: tuple[int, int] | None = None
+        best_distance = -1
+        for dx, dy in directions:
+            if not world.in_bounds(self.x + dx, self.y + dy):
+                continue
+            if not world.get_tile(self.x + dx, self.y + dy).walkable:
+                continue
+            dist = 1
+            nx, ny = self.x + dx, self.y + dy
+            while world.in_bounds(nx, ny) and (nx, ny) in self.memory:
+                nx += dx
+                ny += dy
+                dist += 1
+            if not world.in_bounds(nx, ny):
+                continue
+            if dist > best_distance:
+                best_distance = dist
+                best = (dx, dy)
+        if best is not None:
+            return MoveAction(*best)
+        return None
+
     def rest(self) -> None:
         """Recover energy while increasing hunger and thirst."""
 
@@ -249,9 +275,9 @@ class Entity:
                 if self.needs.hunger > 5 and self.inventory.items.get(food, 0) > 0:
                     return ConsumeAction(food)
 
-        if self.needs.thirst >= 12 and self.inventory.items.get(Resource.WATER, 0) > 0:
+        if self.needs.thirst >= 8 and self.inventory.items.get(Resource.WATER, 0) > 0:
             return ConsumeAction(Resource.WATER)
-        if self.needs.hunger >= 12:
+        if self.needs.hunger >= 8:
             for food in (Resource.MEAT, Resource.BERRIES):
                 if self.inventory.items.get(food, 0) > 0:
                     return ConsumeAction(food)
@@ -284,12 +310,15 @@ class Entity:
             if world.in_bounds(nx, ny) and world.get_tile(nx, ny).resources:
                 return GatherAction()
 
-        if self.needs.thirst >= 50 and self.inventory.items.get(Resource.WATER, 0) == 0:
+        if self.needs.thirst >= 15 and self.inventory.items.get(Resource.WATER, 0) == 0:
             loc = self.remembered_adjacent_tile_for_resource(world, Resource.WATER)
             if loc:
                 return MoveToAction(target=loc)
+            explore = self.step_toward_unexplored(world)
+            if explore:
+                return explore
 
-        if self.needs.hunger >= 50 and not any(
+        if self.needs.hunger >= 15 and not any(
             self.inventory.items.get(res, 0) > 0
             for res in (Resource.MEAT, Resource.BERRIES)
         ):
@@ -297,6 +326,9 @@ class Entity:
                 loc = self.remembered_adjacent_tile_for_resource(world, res)
                 if loc:
                     return MoveToAction(target=loc)
+            explore = self.step_toward_unexplored(world)
+            if explore:
+                return explore
 
         if self.needs.loneliness >= 8:
             dx, dy = random.choice(directions)
@@ -380,7 +412,7 @@ class Entity:
         self.perceive(world)
 
         if self.needs.hunger >= 20 or self.needs.thirst >= 20:
-            self.needs.health = max(0, self.needs.health - 5)
+            self.needs.health = max(0, self.needs.health - 0.25)
             self.needs.injuries += 1
 
         if (

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -1,4 +1,5 @@
 from civsim.entity import Entity
+from civsim.actions import MoveAction
 from civsim.simulation import Simulation
 from civsim.world import World
 
@@ -53,4 +54,15 @@ def test_entities_die_and_are_removed() -> None:
     e.needs.thirst = 20
     sim = Simulation(world=world, entities=[e])
     sim.step()
-    assert not sim.entities
+    assert len(sim.entities) == 1
+    assert sim.entities[0].needs.health == 4.75
+
+
+def test_seek_unexplored_when_no_known_resources() -> None:
+    world = World(width=5, height=5, seed=1)
+    e = Entity(id=0, x=2, y=2)
+    e.needs.hunger = 15
+    action = e.plan_action(world)
+    assert isinstance(action, MoveAction)
+    nx, ny = e.x + action.dx, e.y + action.dy
+    assert (nx, ny) not in e.memory


### PR DESCRIPTION
## Summary
- reduce health loss from hunger or thirst
- adjust simulation test to expect slower starvation
- lower thresholds for eating and gathering
- prefer exploring new territory when in need

## Testing
- `black --check .`
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6846527847bc8324a7a978069a5fae12