### PR TITLE
Add community mechanics and storage sharing

### DIFF
--- a/src/civsim/__init__.py
+++ b/src/civsim/__init__.py
@@ -1,6 +1,7 @@
 """Convenience exports for the civsim package."""
 
 from .world import World, Biome, Building
+from .community import Community, CommunityTask
 from .entity import Entity, ReproductionRules
 from .simulation import Simulation
 from .actions import (
@@ -23,6 +24,8 @@ __all__ = [
     "World",
     "Biome",
     "Building",
+    "Community",
+    "CommunityTask",
     "Entity",
     "ReproductionRules",
     "Simulation",

--- a/src/civsim/community.py
+++ b/src/civsim/community.py
@@ -1,0 +1,34 @@
+"""Basic community and task structures."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List, Set
+
+
+@dataclass
+class CommunityTask:
+    """A placeholder community task."""
+
+    description: str
+    assigned: Set[int] = field(default_factory=set)
+    completed: bool = False
+
+
+@dataclass
+class Community:
+    """Group of entities sharing tasks and storage."""
+
+    id: int
+    member_ids: Set[int] = field(default_factory=set)
+    tasks: List[CommunityTask] = field(default_factory=list)
+    storage_id: int | None = None
+
+    def add_member(self, entity_id: int) -> None:
+        self.member_ids.add(entity_id)
+
+    def remove_member(self, entity_id: int) -> None:
+        self.member_ids.discard(entity_id)
+
+    def add_task(self, task: CommunityTask) -> None:
+        self.tasks.append(task)


### PR DESCRIPTION
## Summary
- introduce `Community` data class
- add shared storage buildings and deposit/withdraw logic
- let entities join communities and use storage
- expose communities in `__init__`
- test storing items and moving toward storage

## Testing
- `black --check .`
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68472c856f70832481edb3f06501683c