### PR TITLE
Increase early resources and infinite water

### DIFF
--- a/src/civsim/__init__.py
+++ b/src/civsim/__init__.py
@@ -19,6 +19,7 @@ from .visualize import (
     render_memory_ascii,
 )
 from .ui import SimulationUI
+from .colors import BIOME_COLORS, RESOURCE_COLORS
 
 __all__ = [
     "World",
@@ -35,6 +36,8 @@ __all__ = [
     "GatherAction",
     "RestAction",
     "ConsumeAction",
+    "BIOME_COLORS",
+    "RESOURCE_COLORS",
     "render_ascii",
     "render_svg",
     "render_vision_ascii",

--- a/src/civsim/colors.py
+++ b/src/civsim/colors.py
@@ -1,0 +1,28 @@
+"""Shared color mappings for biomes and resources."""
+
+from __future__ import annotations
+
+from .world import Biome, Resource
+
+BIOME_COLORS: dict[Biome, str] = {
+    Biome.PLAINS: "#a4c689",
+    Biome.FOREST: "#228b22",
+    Biome.DESERT: "#e0c469",
+    Biome.WATER: "#1e90ff",
+    Biome.MOUNTAIN: "#888888",
+}
+
+RESOURCE_COLORS: dict[Resource, str] = {
+    Resource.WOOD: "#8b4513",
+    Resource.STONE: "#808080",
+    Resource.CLAY: "#b5651d",
+    Resource.WATER: "#00bfff",
+    Resource.BERRY_BUSH: "#ff6347",
+    Resource.ANIMAL: "#fafad2",
+    Resource.BERRIES: "#ff9999",
+    Resource.MEAT: "#cd5c5c",
+    Resource.IRON: "#b0b0b0",
+    Resource.COPPER: "#b87333",
+    Resource.GOLD: "#ffd700",
+    Resource.COAL: "#2f4f4f",
+}

--- a/src/civsim/simulation.py
+++ b/src/civsim/simulation.py
@@ -74,10 +74,11 @@ class Simulation:
             mem_union: set[tuple[int, int]] = set()
             for eid in house.occupant_ids:
                 if eid in ent_map:
-                    mem_union |= ent_map[eid].memory
+                    mem_union |= set(ent_map[eid].memory.keys())
             for eid in house.occupant_ids:
                 if eid in ent_map:
-                    ent_map[eid].memory |= mem_union
+                    for pos in mem_union:
+                        ent_map[eid].remember(*pos, persistent=True)
 
         for i, h1 in enumerate(houses):
             for h2 in houses[i + 1 :]:
@@ -85,10 +86,11 @@ class Simulation:
                     mem_union = set()
                     for eid in h1.occupant_ids + h2.occupant_ids:
                         if eid in ent_map:
-                            mem_union |= ent_map[eid].memory
+                            mem_union |= set(ent_map[eid].memory.keys())
                     for eid in h1.occupant_ids + h2.occupant_ids:
                         if eid in ent_map:
-                            ent_map[eid].memory |= mem_union
+                            for pos in mem_union:
+                                ent_map[eid].remember(*pos, persistent=True)
 
     def _complete_construction(self) -> None:
         """Finalize finished construction sites and reward builders."""

--- a/src/civsim/ui.py
+++ b/src/civsim/ui.py
@@ -7,7 +7,7 @@ from typing import Optional
 
 from .simulation import Simulation
 from .entity import Entity
-from .world import Biome, Resource
+from .colors import BIOME_COLORS, RESOURCE_COLORS
 
 
 class SimulationUI:
@@ -122,41 +122,8 @@ class SimulationUI:
         self.canvas.delete("all")
         world = self.sim.world
         ts = self.tile_size
-        colors = {
-            Biome.PLAINS: "#a4c689",
-            Biome.FOREST: "#228b22",
-            Biome.DESERT: "#e0c469",
-            Biome.WATER: "#1e90ff",
-            Biome.MOUNTAIN: "#888888",
-        }
-        res_colors = {
-            Resource.WOOD: "#8b4513",
-            Resource.STONE: "#808080",
-            Resource.CLAY: "#b5651d",
-            Resource.WATER: "#00bfff",
-            Resource.BERRY_BUSH: "#ff6347",
-            Resource.ANIMAL: "#fafad2",
-            Resource.BERRIES: "#ff9999",
-            Resource.MEAT: "#cd5c5c",
-            Resource.IRON: "#b0b0b0",
-            Resource.COPPER: "#b87333",
-            Resource.GOLD: "#ffd700",
-            Resource.COAL: "#2f4f4f",
-        }
-        res_colors = {
-            Resource.WOOD: "#8b4513",
-            Resource.STONE: "#808080",
-            Resource.CLAY: "#b5651d",
-            Resource.WATER: "#00bfff",
-            Resource.BERRY_BUSH: "#ff6347",
-            Resource.ANIMAL: "#fafad2",
-            Resource.BERRIES: "#ff9999",
-            Resource.MEAT: "#cd5c5c",
-            Resource.IRON: "#b0b0b0",
-            Resource.COPPER: "#b87333",
-            Resource.GOLD: "#ffd700",
-            Resource.COAL: "#2f4f4f",
-        }
+        colors = BIOME_COLORS
+        res_colors = RESOURCE_COLORS
         for y in range(world.height):
             for x in range(world.width):
                 tile = world.tiles[y][x]
@@ -211,7 +178,7 @@ class SimulationUI:
                         width=1,
                     )
         if self.show_memory.get():
-            for mx, my in ent.memory:
+            for mx, my in ent.memory.keys():
                 if world.in_bounds(mx, my):
                     self.canvas.create_rectangle(
                         mx * ts,

--- a/src/civsim/visualize.py
+++ b/src/civsim/visualize.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 from typing import List
 
 from .entity import Entity
-from .world import World, Biome, Resource
+from .world import World, Biome
+from .colors import BIOME_COLORS, RESOURCE_COLORS
 
 
 def render_ascii(world: World, entities: List[Entity]) -> str:
@@ -42,41 +43,8 @@ def render_ascii(world: World, entities: List[Entity]) -> str:
 def render_svg(world: World, entities: List[Entity], tile_size: int = 20) -> str:
     """Return an SVG representation of the world with entities and resources."""
 
-    colors = {
-        Biome.PLAINS: "#a4c689",
-        Biome.FOREST: "#228b22",
-        Biome.DESERT: "#e0c469",
-        Biome.WATER: "#1e90ff",
-        Biome.MOUNTAIN: "#888888",
-    }
-    res_colors = {
-        Resource.WOOD: "#8b4513",
-        Resource.STONE: "#808080",
-        Resource.CLAY: "#b5651d",
-        Resource.WATER: "#00bfff",
-        Resource.BERRY_BUSH: "#ff6347",
-        Resource.ANIMAL: "#fafad2",
-        Resource.BERRIES: "#ff9999",
-        Resource.MEAT: "#cd5c5c",
-        Resource.IRON: "#b0b0b0",
-        Resource.COPPER: "#b87333",
-        Resource.GOLD: "#ffd700",
-        Resource.COAL: "#2f4f4f",
-    }
-    res_colors = {
-        Resource.WOOD: "#8b4513",
-        Resource.STONE: "#808080",
-        Resource.CLAY: "#b5651d",
-        Resource.WATER: "#00bfff",
-        Resource.BERRY_BUSH: "#ff6347",
-        Resource.ANIMAL: "#fafad2",
-        Resource.BERRIES: "#ff9999",
-        Resource.MEAT: "#cd5c5c",
-        Resource.IRON: "#b0b0b0",
-        Resource.COPPER: "#b87333",
-        Resource.GOLD: "#ffd700",
-        Resource.COAL: "#2f4f4f",
-    }
+    colors = BIOME_COLORS
+    res_colors = RESOURCE_COLORS
     width_px = world.width * tile_size
     height_px = world.height * tile_size
     parts = [
@@ -163,7 +131,7 @@ def render_memory_ascii(world: World, entity: Entity) -> str:
         for y in range(world.height)
     ]
 
-    for x, y in entity.memory:
+    for x, y in entity.memory.keys():
         if world.in_bounds(x, y):
             grid[y][x] = "#"
 

--- a/tests/test_buildings.py
+++ b/tests/test_buildings.py
@@ -5,7 +5,7 @@ from civsim.simulation import Simulation
 
 
 def test_place_building_blocks_tiles() -> None:
-    world = World(width=5, height=5, seed=1)
+    world = World(width=5, height=5, seed=1, ensure_starting_resources=False)
     for dy in range(3):
         for dx in range(2):
             tile = world.get_tile(1 + dx, 1 + dy)
@@ -21,7 +21,7 @@ def test_place_building_blocks_tiles() -> None:
 
 
 def test_cannot_overlap_building() -> None:
-    world = World(width=5, height=5, seed=2)
+    world = World(width=5, height=5, seed=2, ensure_starting_resources=False)
     b1 = Building(id=0, x=0, y=0, width=2, height=2)
     assert world.place_building(b1)
     b2 = Building(id=1, x=1, y=1, width=2, height=2)
@@ -29,7 +29,7 @@ def test_cannot_overlap_building() -> None:
 
 
 def test_build_action_places_building() -> None:
-    world = World(width=4, height=4, seed=3)
+    world = World(width=4, height=4, seed=3, ensure_starting_resources=False)
     for dy in range(2):
         for dx in range(2):
             tile = world.get_tile(1 + dx, 1 + dy)
@@ -58,7 +58,7 @@ def test_build_action_places_building() -> None:
 
 
 def test_group_building_speeds_up() -> None:
-    world = World(width=4, height=4, seed=4)
+    world = World(width=4, height=4, seed=4, ensure_starting_resources=False)
     for dy in range(2):
         for dx in range(2):
             tile = world.get_tile(1 + dx, 1 + dy)

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -5,7 +5,7 @@ from civsim.actions import MoveToAction, ConsumeAction
 
 
 def test_entity_movement_and_gathering() -> None:
-    world = World(width=3, height=3, seed=2)
+    world = World(width=3, height=3, seed=2, ensure_starting_resources=False)
     entity = Entity(id=1, x=1, y=1)
     tile = world.get_tile(1, 2)
     tile.resources.clear()
@@ -19,7 +19,7 @@ def test_entity_movement_and_gathering() -> None:
 
 
 def test_entity_needs_update_and_rest() -> None:
-    world = World(width=3, height=3, seed=1)
+    world = World(width=3, height=3, seed=1, ensure_starting_resources=False)
     entity = Entity(id=1, x=1, y=1)
     entity.needs.energy = 1
 
@@ -30,7 +30,7 @@ def test_entity_needs_update_and_rest() -> None:
 
 
 def test_entity_age_causes_death() -> None:
-    world = World(width=3, height=3, seed=1)
+    world = World(width=3, height=3, seed=1, ensure_starting_resources=False)
     entity = Entity(id=1, x=1, y=1, max_age=2)
 
     entity.take_turn(world)
@@ -40,7 +40,7 @@ def test_entity_age_causes_death() -> None:
 
 
 def test_entity_memory_and_relationships() -> None:
-    world = World(width=3, height=3, seed=1)
+    world = World(width=3, height=3, seed=1, ensure_starting_resources=False)
     e1 = Entity(id=1, x=1, y=1)
     e2 = Entity(id=2, x=1, y=1)
 
@@ -66,7 +66,7 @@ def test_can_reproduce_rules() -> None:
 
 
 def test_loneliness_updates_with_neighbors() -> None:
-    world = World(width=3, height=3, seed=1)
+    world = World(width=3, height=3, seed=1, ensure_starting_resources=False)
     e1 = Entity(id=1, x=1, y=1)
     e2 = Entity(id=2, x=2, y=1)
     sim = Simulation(world=world, entities=[e1, e2])
@@ -78,7 +78,7 @@ def test_loneliness_updates_with_neighbors() -> None:
 
 
 def test_entity_moves_to_remembered_resource() -> None:
-    world = World(width=3, height=2, seed=1)
+    world = World(width=3, height=2, seed=1, ensure_starting_resources=False)
     tile = world.get_tile(2, 0)
     tile.resources.clear()
     tile.resources[Resource.BERRY_BUSH] = 1
@@ -89,7 +89,8 @@ def test_entity_moves_to_remembered_resource() -> None:
     mid.walkable = True
 
     e = Entity(id=1, x=0, y=0)
-    e.memory.update({(0, 0), (1, 0), (2, 0)})
+    for pos in {(0, 0), (1, 0), (2, 0)}:
+        e.memory[pos] = float("inf")
     e.needs.hunger = 55
 
     for _ in range(2):
@@ -100,7 +101,7 @@ def test_entity_moves_to_remembered_resource() -> None:
 
 
 def test_entity_consumes_food_and_water() -> None:
-    world = World(width=3, height=3, seed=1)
+    world = World(width=3, height=3, seed=1, ensure_starting_resources=False)
     e = Entity(id=1, x=1, y=1)
     e.inventory.add(Resource.BERRIES)
     e.inventory.add(Resource.WATER)
@@ -117,7 +118,7 @@ def test_entity_consumes_food_and_water() -> None:
 
 
 def test_health_regeneration() -> None:
-    world = World(width=3, height=3, seed=1)
+    world = World(width=3, height=3, seed=1, ensure_starting_resources=False)
     e = Entity(id=1, x=1, y=1)
     e.needs.health = 90
     e.needs.hunger = 1
@@ -128,7 +129,7 @@ def test_health_regeneration() -> None:
 
 
 def test_entity_seeks_wood_for_building() -> None:
-    world = World(width=3, height=2, seed=1)
+    world = World(width=3, height=2, seed=1, ensure_starting_resources=False)
     tile = world.get_tile(2, 0)
     tile.resources.clear()
     tile.resources[Resource.WOOD] = 1
@@ -138,7 +139,8 @@ def test_entity_seeks_wood_for_building() -> None:
     mid.walkable = True
 
     e = Entity(id=1, x=0, y=0)
-    e.memory.update({(0, 0), (1, 0), (2, 0)})
+    for pos in {(0, 0), (1, 0), (2, 0)}:
+        e.memory[pos] = float("inf")
     e.needs.energy = 50
 
     action = e.plan_action(world)
@@ -147,13 +149,14 @@ def test_entity_seeks_wood_for_building() -> None:
 
 
 def test_storage_deposit_and_withdraw() -> None:
-    world = World(width=3, height=3, seed=1)
+    world = World(width=3, height=3, seed=1, ensure_starting_resources=False)
     storage = Building(id=0, x=1, y=1, width=1, height=1, name="storage")
     assert world.place_building(storage)
 
     e = Entity(id=1, x=0, y=1)
     e.inventory.add(Resource.WOOD, 2)
-    e.memory.update({(0, 1), (1, 1)})
+    for pos in {(0, 1), (1, 1)}:
+        e.memory[pos] = float("inf")
 
     action = e.plan_action(world)
     # move adjacent to storage since we are already next to it
@@ -169,14 +172,15 @@ def test_storage_deposit_and_withdraw() -> None:
 
 
 def test_move_to_storage_for_water() -> None:
-    world = World(width=3, height=2, seed=1)
+    world = World(width=3, height=2, seed=1, ensure_starting_resources=False)
     storage = Building(id=0, x=2, y=0, width=1, height=1, name="storage")
     world.get_tile(2, 0).resources.clear()
     world.get_tile(2, 0).walkable = True
     assert world.place_building(storage)
     storage.inventory[Resource.WATER] = 1
     e = Entity(id=1, x=0, y=0)
-    e.memory.update({(0, 0), (1, 0), (2, 0)})
+    for pos in {(0, 0), (1, 0), (2, 0)}:
+        e.memory[pos] = float("inf")
     e.needs.thirst = 9
     action = e.plan_action(world)
     assert isinstance(action, MoveToAction)

--- a/tests/test_households.py
+++ b/tests/test_households.py
@@ -4,7 +4,7 @@ from civsim.simulation import Simulation
 
 
 def test_house_capacity_and_memory_sharing() -> None:
-    world = World(width=5, height=5, seed=1)
+    world = World(width=5, height=5, seed=1, ensure_starting_resources=False)
     for dy in range(2):
         for dx in range(2):
             tile = world.get_tile(dx, dy)
@@ -28,7 +28,7 @@ def test_house_capacity_and_memory_sharing() -> None:
     e4 = Entity(id=4, x=3, y=0)
     assert e3.bind_to_house(house2)
     assert e4.bind_to_house(house2)
-    e3.memory.add((4, 4))
+    e3.memory[(4, 4)] = float("inf")
     sim = Simulation(world=world, entities=[e1, e2, e3, e4])
     sim._share_house_memory()
     assert (4, 4) in e4.memory

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -1,11 +1,11 @@
 from civsim.entity import Entity
-from civsim.actions import MoveAction
+from civsim.actions import MoveToAction
 from civsim.simulation import Simulation
 from civsim.world import World
 
 
 def test_simulation_step() -> None:
-    world = World(width=5, height=5, seed=3)
+    world = World(width=5, height=5, seed=3, ensure_starting_resources=False)
     entities = [Entity(id=0, x=2, y=2)]
     sim = Simulation(world=world, entities=entities)
     sim.step()
@@ -13,7 +13,7 @@ def test_simulation_step() -> None:
 
 
 def test_reproduction_creates_new_entity() -> None:
-    world = World(width=3, height=3, seed=2)
+    world = World(width=3, height=3, seed=2, ensure_starting_resources=False)
     e1 = Entity(id=0, x=1, y=1)
     e2 = Entity(id=1, x=1, y=1)
     e1.age = 20
@@ -26,7 +26,7 @@ def test_reproduction_creates_new_entity() -> None:
 
 
 def test_entities_do_not_overlap_after_step() -> None:
-    world = World(width=3, height=3, seed=1)
+    world = World(width=3, height=3, seed=1, ensure_starting_resources=False)
     e1 = Entity(id=0, x=1, y=1)
     e2 = Entity(id=1, x=1, y=1)
     sim = Simulation(world=world, entities=[e1, e2])
@@ -36,7 +36,7 @@ def test_entities_do_not_overlap_after_step() -> None:
 
 
 def test_reproduction_requires_conditions() -> None:
-    world = World(width=3, height=3, seed=3)
+    world = World(width=3, height=3, seed=3, ensure_starting_resources=False)
     e1 = Entity(id=0, x=1, y=1)
     e2 = Entity(id=1, x=1, y=1)
     e1.age = 5  # below threshold
@@ -47,7 +47,7 @@ def test_reproduction_requires_conditions() -> None:
 
 
 def test_entities_die_and_are_removed() -> None:
-    world = World(width=3, height=3, seed=1)
+    world = World(width=3, height=3, seed=1, ensure_starting_resources=False)
     e = Entity(id=0, x=1, y=1)
     e.needs.health = 5
     e.needs.hunger = 20
@@ -59,10 +59,9 @@ def test_entities_die_and_are_removed() -> None:
 
 
 def test_seek_unexplored_when_no_known_resources() -> None:
-    world = World(width=5, height=5, seed=1)
+    world = World(width=5, height=5, seed=1, ensure_starting_resources=False)
     e = Entity(id=0, x=2, y=2)
     e.needs.hunger = 15
     action = e.plan_action(world)
-    assert isinstance(action, MoveAction)
-    nx, ny = e.x + action.dx, e.y + action.dy
-    assert (nx, ny) not in e.memory
+    assert isinstance(action, MoveToAction)
+    assert action.target not in e.memory

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -9,7 +9,7 @@ from civsim.entity import Entity
 
 
 def test_render_ascii_dimensions() -> None:
-    world = World(width=4, height=3, seed=0)
+    world = World(width=4, height=3, seed=0, ensure_starting_resources=False)
     entities = [Entity(id=1, x=1, y=1)]
     output = render_ascii(world, entities)
     lines = output.splitlines()
@@ -18,14 +18,14 @@ def test_render_ascii_dimensions() -> None:
 
 
 def test_render_svg_contains_svg_tag() -> None:
-    world = World(width=2, height=2, seed=1)
+    world = World(width=2, height=2, seed=1, ensure_starting_resources=False)
     entities = [Entity(id=1, x=0, y=0)]
     svg = render_svg(world, entities)
     assert svg.startswith("<svg") and svg.endswith("</svg>")
 
 
 def test_render_vision_ascii_marks_tiles() -> None:
-    world = World(width=3, height=3, seed=0)
+    world = World(width=3, height=3, seed=0, ensure_starting_resources=False)
     e = Entity(id=1, x=1, y=1)
     e.traits.perception = 1
     output = render_vision_ascii(world, e)
@@ -37,9 +37,10 @@ def test_render_vision_ascii_marks_tiles() -> None:
 
 
 def test_render_memory_ascii_marks_memory() -> None:
-    world = World(width=3, height=3, seed=0)
+    world = World(width=3, height=3, seed=0, ensure_starting_resources=False)
     e = Entity(id=1, x=1, y=1)
-    e.memory.update({(0, 0), (2, 2)})
+    for pos in {(0, 0), (2, 2)}:
+        e.memory[pos] = float("inf")
     output = render_memory_ascii(world, e)
     lines = output.splitlines()
     assert lines[0][0] == "#"

--- a/tests/test_world.py
+++ b/tests/test_world.py
@@ -3,7 +3,7 @@ from civsim.entity import Entity
 
 
 def test_world_generation() -> None:
-    world = World(width=20, height=20, seed=1)
+    world = World(width=20, height=20, seed=1, ensure_starting_resources=False)
     assert world.width == 20
     assert world.height == 20
     biomes = {tile.biome for row in world.tiles for tile in row}
@@ -11,7 +11,7 @@ def test_world_generation() -> None:
 
 
 def test_resource_tiles_not_walkable() -> None:
-    world = World(width=10, height=10, seed=2)
+    world = World(width=10, height=10, seed=2, ensure_starting_resources=False)
     has_resource = False
     for row in world.tiles:
         for tile in row:
@@ -22,14 +22,14 @@ def test_resource_tiles_not_walkable() -> None:
 
 
 def test_berry_bush_regrows() -> None:
-    world = World(width=3, height=3, seed=1)
+    world = World(width=3, height=3, seed=1, ensure_starting_resources=False)
     tile = world.get_tile(1, 1)
     tile.resources.clear()
     tile.resources[Resource.BERRY_BUSH] = 1
     tile.walkable = False
 
     e = Entity(id=1, x=0, y=0)
-    e.memory.add((1, 1))
+    e.memory[(1, 1)] = float("inf")
     e.move(1, 1, world)
     e.gather(world)
 


### PR DESCRIPTION
## Summary
- place animals and berry bushes more densely during world generation
- guarantee water, berries and animals very close to the spawn point
- keep water tiles after gathering so water is unlimited

## Testing
- `black --check .`
- `ruff check .`
- `pytest -q`
- manual 500 tick simulation

------
https://chatgpt.com/codex/tasks/task_e_6847337ed44c8324978c2c03f24d259b