### PR TITLE
Improve simulation UI with action logs

### DIFF
--- a/src/civsim/simulation.py
+++ b/src/civsim/simulation.py
@@ -49,7 +49,7 @@ class Simulation:
             if occupied[pos] == 0:
                 del occupied[pos]
 
-            entity.take_turn(self.world, set(occupied.keys()))
+            entity.take_turn(self.world, set(occupied.keys()), tick=self.tick)
             if entity.home_id is not None:
                 entity.needs.morale = min(100, entity.needs.morale + 1)
 


### PR DESCRIPTION
## Summary
- expand `Entity` with plan reason and logging support
- log actions each tick through `take_turn`
- pass tick value from `Simulation.step`
- display tick/entity/community info in UI
- add action log widget and detailed entity display

## Testing
- `black --check .`
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684748e528608324843720a08fff39d1