### PR TITLE
Boost forest and wood generation

### DIFF
--- a/tests/test_buildings.py
+++ b/tests/test_buildings.py
@@ -5,7 +5,7 @@ from civsim.simulation import Simulation
 
 
 def test_place_building_blocks_tiles() -> None:
-    world = World(width=5, height=5, seed=1, ensure_starting_resources=False)
+    world = World(width=5, height=5, seed=1)
     for dy in range(3):
         for dx in range(2):
             tile = world.get_tile(1 + dx, 1 + dy)
@@ -21,7 +21,12 @@ def test_place_building_blocks_tiles() -> None:
 
 
 def test_cannot_overlap_building() -> None:
-    world = World(width=5, height=5, seed=2, ensure_starting_resources=False)
+    world = World(width=5, height=5, seed=2)
+    for dy in range(2):
+        for dx in range(2):
+            tile = world.get_tile(dx, dy)
+            tile.resources.clear()
+            tile.walkable = True
     b1 = Building(id=0, x=0, y=0, width=2, height=2)
     assert world.place_building(b1)
     b2 = Building(id=1, x=1, y=1, width=2, height=2)
@@ -29,7 +34,7 @@ def test_cannot_overlap_building() -> None:
 
 
 def test_build_action_places_building() -> None:
-    world = World(width=4, height=4, seed=3, ensure_starting_resources=False)
+    world = World(width=4, height=4, seed=3)
     for dy in range(2):
         for dx in range(2):
             tile = world.get_tile(1 + dx, 1 + dy)
@@ -58,7 +63,7 @@ def test_build_action_places_building() -> None:
 
 
 def test_group_building_speeds_up() -> None:
-    world = World(width=4, height=4, seed=4, ensure_starting_resources=False)
+    world = World(width=4, height=4, seed=4)
     for dy in range(2):
         for dx in range(2):
             tile = world.get_tile(1 + dx, 1 + dy)

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -5,10 +5,13 @@ from civsim.actions import MoveToAction, ConsumeAction
 
 
 def test_entity_movement_and_gathering() -> None:
-    world = World(width=3, height=3, seed=2, ensure_starting_resources=False)
+    world = World(width=3, height=3, seed=2)
     entity = Entity(id=1, x=1, y=1)
+    for dx, dy in ((1, 0), (-1, 0), (0, 1), (0, -1)):
+        t = world.get_tile(entity.x + dx, entity.y + dy)
+        t.resources.clear()
+        t.walkable = True
     tile = world.get_tile(1, 2)
-    tile.resources.clear()
     tile.resources[Resource.WOOD] = 1
     tile.walkable = False
 
@@ -19,7 +22,7 @@ def test_entity_movement_and_gathering() -> None:
 
 
 def test_entity_needs_update_and_rest() -> None:
-    world = World(width=3, height=3, seed=1, ensure_starting_resources=False)
+    world = World(width=3, height=3, seed=1)
     entity = Entity(id=1, x=1, y=1)
     entity.needs.energy = 1
 
@@ -30,7 +33,7 @@ def test_entity_needs_update_and_rest() -> None:
 
 
 def test_entity_age_causes_death() -> None:
-    world = World(width=3, height=3, seed=1, ensure_starting_resources=False)
+    world = World(width=3, height=3, seed=1)
     entity = Entity(id=1, x=1, y=1, max_age=2)
 
     entity.take_turn(world)
@@ -40,7 +43,7 @@ def test_entity_age_causes_death() -> None:
 
 
 def test_entity_memory_and_relationships() -> None:
-    world = World(width=3, height=3, seed=1, ensure_starting_resources=False)
+    world = World(width=3, height=3, seed=1)
     e1 = Entity(id=1, x=1, y=1)
     e2 = Entity(id=2, x=1, y=1)
 
@@ -66,7 +69,7 @@ def test_can_reproduce_rules() -> None:
 
 
 def test_loneliness_updates_with_neighbors() -> None:
-    world = World(width=3, height=3, seed=1, ensure_starting_resources=False)
+    world = World(width=3, height=3, seed=1)
     e1 = Entity(id=1, x=1, y=1)
     e2 = Entity(id=2, x=2, y=1)
     sim = Simulation(world=world, entities=[e1, e2])
@@ -78,9 +81,13 @@ def test_loneliness_updates_with_neighbors() -> None:
 
 
 def test_entity_moves_to_remembered_resource() -> None:
-    world = World(width=3, height=2, seed=1, ensure_starting_resources=False)
+    world = World(width=3, height=2, seed=1)
+    for y in range(2):
+        for x in range(3):
+            t = world.get_tile(x, y)
+            t.resources.clear()
+            t.walkable = True
     tile = world.get_tile(2, 0)
-    tile.resources.clear()
     tile.resources[Resource.BERRY_BUSH] = 1
     tile.walkable = False
     world.get_tile(0, 0).resources.clear()
@@ -101,7 +108,7 @@ def test_entity_moves_to_remembered_resource() -> None:
 
 
 def test_entity_consumes_food_and_water() -> None:
-    world = World(width=3, height=3, seed=1, ensure_starting_resources=False)
+    world = World(width=3, height=3, seed=1)
     e = Entity(id=1, x=1, y=1)
     e.inventory.add(Resource.BERRIES)
     e.inventory.add(Resource.WATER)
@@ -118,7 +125,7 @@ def test_entity_consumes_food_and_water() -> None:
 
 
 def test_health_regeneration() -> None:
-    world = World(width=3, height=3, seed=1, ensure_starting_resources=False)
+    world = World(width=3, height=3, seed=1)
     e = Entity(id=1, x=1, y=1)
     e.needs.health = 90
     e.needs.hunger = 1
@@ -129,9 +136,13 @@ def test_health_regeneration() -> None:
 
 
 def test_entity_seeks_wood_for_building() -> None:
-    world = World(width=3, height=2, seed=1, ensure_starting_resources=False)
+    world = World(width=3, height=2, seed=1)
+    for y in range(2):
+        for x in range(3):
+            t = world.get_tile(x, y)
+            t.resources.clear()
+            t.walkable = True
     tile = world.get_tile(2, 0)
-    tile.resources.clear()
     tile.resources[Resource.WOOD] = 1
     tile.walkable = False
     mid = world.get_tile(1, 0)
@@ -149,7 +160,7 @@ def test_entity_seeks_wood_for_building() -> None:
 
 
 def test_storage_deposit_and_withdraw() -> None:
-    world = World(width=3, height=3, seed=1, ensure_starting_resources=False)
+    world = World(width=3, height=3, seed=1)
     storage = Building(id=0, x=1, y=1, width=1, height=1, name="storage")
     assert world.place_building(storage)
 
@@ -172,7 +183,12 @@ def test_storage_deposit_and_withdraw() -> None:
 
 
 def test_move_to_storage_for_water() -> None:
-    world = World(width=3, height=2, seed=1, ensure_starting_resources=False)
+    world = World(width=3, height=2, seed=1)
+    for y in range(2):
+        for x in range(3):
+            t = world.get_tile(x, y)
+            t.resources.clear()
+            t.walkable = True
     storage = Building(id=0, x=2, y=0, width=1, height=1, name="storage")
     world.get_tile(2, 0).resources.clear()
     world.get_tile(2, 0).walkable = True

--- a/tests/test_households.py
+++ b/tests/test_households.py
@@ -4,7 +4,7 @@ from civsim.simulation import Simulation
 
 
 def test_house_capacity_and_memory_sharing() -> None:
-    world = World(width=5, height=5, seed=1, ensure_starting_resources=False)
+    world = World(width=5, height=5, seed=1)
     for dy in range(2):
         for dx in range(2):
             tile = world.get_tile(dx, dy)

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -5,7 +5,7 @@ from civsim.world import World
 
 
 def test_simulation_step() -> None:
-    world = World(width=5, height=5, seed=3, ensure_starting_resources=False)
+    world = World(width=5, height=5, seed=3)
     entities = [Entity(id=0, x=2, y=2)]
     sim = Simulation(world=world, entities=entities)
     sim.step()
@@ -13,7 +13,7 @@ def test_simulation_step() -> None:
 
 
 def test_reproduction_creates_new_entity() -> None:
-    world = World(width=3, height=3, seed=2, ensure_starting_resources=False)
+    world = World(width=3, height=3, seed=2)
     e1 = Entity(id=0, x=1, y=1)
     e2 = Entity(id=1, x=1, y=1)
     e1.age = 20
@@ -26,7 +26,12 @@ def test_reproduction_creates_new_entity() -> None:
 
 
 def test_entities_do_not_overlap_after_step() -> None:
-    world = World(width=3, height=3, seed=1, ensure_starting_resources=False)
+    world = World(width=3, height=3, seed=1)
+    for y in range(3):
+        for x in range(3):
+            tile = world.get_tile(x, y)
+            tile.resources.clear()
+            tile.walkable = True
     e1 = Entity(id=0, x=1, y=1)
     e2 = Entity(id=1, x=1, y=1)
     sim = Simulation(world=world, entities=[e1, e2])
@@ -36,7 +41,7 @@ def test_entities_do_not_overlap_after_step() -> None:
 
 
 def test_reproduction_requires_conditions() -> None:
-    world = World(width=3, height=3, seed=3, ensure_starting_resources=False)
+    world = World(width=3, height=3, seed=3)
     e1 = Entity(id=0, x=1, y=1)
     e2 = Entity(id=1, x=1, y=1)
     e1.age = 5  # below threshold
@@ -47,7 +52,7 @@ def test_reproduction_requires_conditions() -> None:
 
 
 def test_entities_die_and_are_removed() -> None:
-    world = World(width=3, height=3, seed=1, ensure_starting_resources=False)
+    world = World(width=3, height=3, seed=1)
     e = Entity(id=0, x=1, y=1)
     e.needs.health = 5
     e.needs.hunger = 20
@@ -59,7 +64,12 @@ def test_entities_die_and_are_removed() -> None:
 
 
 def test_seek_unexplored_when_no_known_resources() -> None:
-    world = World(width=5, height=5, seed=1, ensure_starting_resources=False)
+    world = World(width=5, height=5, seed=1)
+    for y in range(5):
+        for x in range(5):
+            t = world.get_tile(x, y)
+            t.resources.clear()
+            t.walkable = True
     e = Entity(id=0, x=2, y=2)
     e.needs.hunger = 15
     action = e.plan_action(world)

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -9,7 +9,7 @@ from civsim.entity import Entity
 
 
 def test_render_ascii_dimensions() -> None:
-    world = World(width=4, height=3, seed=0, ensure_starting_resources=False)
+    world = World(width=4, height=3, seed=0)
     entities = [Entity(id=1, x=1, y=1)]
     output = render_ascii(world, entities)
     lines = output.splitlines()
@@ -18,14 +18,14 @@ def test_render_ascii_dimensions() -> None:
 
 
 def test_render_svg_contains_svg_tag() -> None:
-    world = World(width=2, height=2, seed=1, ensure_starting_resources=False)
+    world = World(width=2, height=2, seed=1)
     entities = [Entity(id=1, x=0, y=0)]
     svg = render_svg(world, entities)
     assert svg.startswith("<svg") and svg.endswith("</svg>")
 
 
 def test_render_vision_ascii_marks_tiles() -> None:
-    world = World(width=3, height=3, seed=0, ensure_starting_resources=False)
+    world = World(width=3, height=3, seed=0)
     e = Entity(id=1, x=1, y=1)
     e.traits.perception = 1
     output = render_vision_ascii(world, e)
@@ -37,7 +37,7 @@ def test_render_vision_ascii_marks_tiles() -> None:
 
 
 def test_render_memory_ascii_marks_memory() -> None:
-    world = World(width=3, height=3, seed=0, ensure_starting_resources=False)
+    world = World(width=3, height=3, seed=0)
     e = Entity(id=1, x=1, y=1)
     for pos in {(0, 0), (2, 2)}:
         e.memory[pos] = float("inf")

--- a/tests/test_world.py
+++ b/tests/test_world.py
@@ -1,17 +1,17 @@
-from civsim.world import World, Biome, Resource
+from civsim.world import World, Resource
 from civsim.entity import Entity
 
 
 def test_world_generation() -> None:
-    world = World(width=20, height=20, seed=1, ensure_starting_resources=False)
+    world = World(width=20, height=20, seed=1)
     assert world.width == 20
     assert world.height == 20
     biomes = {tile.biome for row in world.tiles for tile in row}
-    assert {Biome.PLAINS, Biome.FOREST, Biome.DESERT, Biome.WATER}.issubset(biomes)
+    assert len(biomes) >= 3
 
 
 def test_resource_tiles_not_walkable() -> None:
-    world = World(width=10, height=10, seed=2, ensure_starting_resources=False)
+    world = World(width=10, height=10, seed=2)
     has_resource = False
     for row in world.tiles:
         for tile in row:
@@ -22,7 +22,7 @@ def test_resource_tiles_not_walkable() -> None:
 
 
 def test_berry_bush_regrows() -> None:
-    world = World(width=3, height=3, seed=1, ensure_starting_resources=False)
+    world = World(width=3, height=3, seed=1)
     tile = world.get_tile(1, 1)
     tile.resources.clear()
     tile.resources[Resource.BERRY_BUSH] = 1


### PR DESCRIPTION
## Summary
- remove `ensure_starting_resources` option
- always spawn extra wood and forest-biased biomes
- update tests for new world generation

## Testing
- `black --check .`
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68474b3f8c948324ad66720b3c391aaf