### PR TITLE
Infinite water & house display

### DIFF
--- a/src/civsim/ui.py
+++ b/src/civsim/ui.py
@@ -144,6 +144,15 @@ class SimulationUI:
                     fill=color,
                     outline="black",
                 )
+                if tile.building_id is not None:
+                    self.canvas.create_rectangle(
+                        x * ts,
+                        y * ts,
+                        (x + 1) * ts,
+                        (y + 1) * ts,
+                        fill="#666666",
+                        outline="black",
+                    )
                 if tile.resources:
                     cx = x * ts + ts // 2
                     cy = y * ts + ts // 2
@@ -200,8 +209,12 @@ class SimulationUI:
 
     def update_info(self) -> None:
         """Update the info panel for the currently selected entity."""
+        houses = sum(1 for b in self.sim.world.buildings if b.name == "house")
         self.summary_var.set(
-            f"Tick: {self.sim.tick}\nEntities: {len(self.sim.entities)}\nCommunities: {len(self.sim.world.communities)}"
+            f"Tick: {self.sim.tick}\n"
+            f"Entities: {len(self.sim.entities)}\n"
+            f"Houses: {houses}\n"
+            f"Communities: {len(self.sim.world.communities)}"
         )
 
         if self.selected is None and self.selected_tile is not None:

--- a/src/civsim/world.py
+++ b/src/civsim/world.py
@@ -288,6 +288,11 @@ class World:
                     self._place_wood_cluster(x, y, rng, cluster)
         self._ensure_starting_resources(rng)
 
+        for row in self.tiles:
+            for tile in row:
+                if tile.biome is Biome.WATER:
+                    tile.resources[Resource.WATER] = 1
+
     def in_bounds(self, x: int, y: int) -> bool:
         """Return True if the coordinates are inside the map."""
 
@@ -352,12 +357,11 @@ class World:
             ],
             Biome.PLAINS: [
                 (Resource.BERRY_BUSH, 0.6),
-                (Resource.WATER, 0.2),
                 (Resource.ANIMAL, 0.5),
                 (Resource.WOOD, 0.1),
                 (Resource.STONE, 0.1),
                 (Resource.IRON, 0.05),
-                (None, 0.2),
+                (None, 0.4),
             ],
             Biome.DESERT: [
                 (Resource.STONE, 0.4),
@@ -366,8 +370,7 @@ class World:
                 (Resource.COPPER, 0.05),
                 (Resource.COAL, 0.05),
                 (Resource.GOLD, 0.05),
-                (Resource.WATER, 0.05),
-                (None, 0.4),
+                (None, 0.45),
             ],
             Biome.MOUNTAIN: [
                 (Resource.STONE, 0.5),
@@ -378,8 +381,8 @@ class World:
                 (None, 0.5),
             ],
             Biome.WATER: [
-                (Resource.WATER, 0.6),
-                (Resource.ANIMAL, 0.4),
+                (Resource.ANIMAL, 0.6),
+                (None, 0.4),
             ],
         }
 
@@ -488,7 +491,6 @@ class World:
                     break
 
         for _ in range(2):
-            _place(Resource.WATER)
             _place(Resource.BERRY_BUSH)
             _place(Resource.ANIMAL)
         if self.width >= 5 and self.height >= 5:


### PR DESCRIPTION
## Summary
- remove discrete water nodes, make water biomes provide infinite water
- show houses on the UI map and include house count in the sidebar
- treat water biomes as water resources in entity logic

## Testing
- `black --check .`
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684758568c3c832481c8a8ea179838fe